### PR TITLE
Transactions and custom triggers support

### DIFF
--- a/EntityFrameworkCore.Triggered.sln
+++ b/EntityFrameworkCore.Triggered.sln
@@ -21,6 +21,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFrameworkCore.Trigger
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFrameworkCore.Triggered.Tests", "test\EntityFrameworkCore.Triggered.Tests\EntityFrameworkCore.Triggered.Tests.csproj", "{93EA656F-C065-450E-83C4-9CD510BF03A8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkCore.Triggered.Transactions.Abstractions", "src\EntityFrameworkCore.Triggered.Transactions.Abstractions\EntityFrameworkCore.Triggered.Transactions.Abstractions.csproj", "{E07F11E4-9B0E-4639-948B-24517C04A121}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkCore.Triggered.Transactions", "src\EntityFrameworkCore.Triggered.Transactions\EntityFrameworkCore.Triggered.Transactions.csproj", "{D1F91AA5-9A1F-4817-874F-D5A7707EC150}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkCore.Triggered.Transactions.Tests", "test\EntityFrameworkCore.Triggered.Transactions.Tests\EntityFrameworkCore.Triggered.Transactions.Tests.csproj", "{20CD4CB9-A061-4C32-8F9E-E2C26D19A219}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +45,18 @@ Global
 		{93EA656F-C065-450E-83C4-9CD510BF03A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{93EA656F-C065-450E-83C4-9CD510BF03A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{93EA656F-C065-450E-83C4-9CD510BF03A8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E07F11E4-9B0E-4639-948B-24517C04A121}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E07F11E4-9B0E-4639-948B-24517C04A121}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E07F11E4-9B0E-4639-948B-24517C04A121}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E07F11E4-9B0E-4639-948B-24517C04A121}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1F91AA5-9A1F-4817-874F-D5A7707EC150}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1F91AA5-9A1F-4817-874F-D5A7707EC150}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1F91AA5-9A1F-4817-874F-D5A7707EC150}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1F91AA5-9A1F-4817-874F-D5A7707EC150}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20CD4CB9-A061-4C32-8F9E-E2C26D19A219}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20CD4CB9-A061-4C32-8F9E-E2C26D19A219}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20CD4CB9-A061-4C32-8F9E-E2C26D19A219}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20CD4CB9-A061-4C32-8F9E-E2C26D19A219}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -47,6 +65,9 @@ Global
 		{B338AEB6-4D18-4069-AE00-9A1E33C638F4} = {EDFABD48-3C79-47AE-B84C-47CE2A52C20D}
 		{F7EE1BD9-BFCB-46DB-BCF6-52661B6C346B} = {EDFABD48-3C79-47AE-B84C-47CE2A52C20D}
 		{93EA656F-C065-450E-83C4-9CD510BF03A8} = {0FAE4F6A-93BB-453C-8FB4-B24A9F30DA59}
+		{E07F11E4-9B0E-4639-948B-24517C04A121} = {EDFABD48-3C79-47AE-B84C-47CE2A52C20D}
+		{D1F91AA5-9A1F-4817-874F-D5A7707EC150} = {EDFABD48-3C79-47AE-B84C-47CE2A52C20D}
+		{20CD4CB9-A061-4C32-8F9E-E2C26D19A219} = {0FAE4F6A-93BB-453C-8FB4-B24A9F30DA59}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {847A0017-23D6-4513-B78E-CAADBD836A7D}

--- a/src/EntityFrameworkCore.Triggered.Abstractions/EntityFrameworkCore.Triggered.Abstractions.csproj
+++ b/src/EntityFrameworkCore.Triggered.Abstractions/EntityFrameworkCore.Triggered.Abstractions.csproj
@@ -5,7 +5,4 @@
     <RootNamespace>EntityFrameworkCore.Triggered</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup>
-  </ItemGroup>
-
 </Project>

--- a/src/EntityFrameworkCore.Triggered.Abstractions/ITriggerSession.cs
+++ b/src/EntityFrameworkCore.Triggered.Abstractions/ITriggerSession.cs
@@ -9,7 +9,22 @@ namespace EntityFrameworkCore.Triggered
 {
     public interface ITriggerSession
     {
+        /// <summary>
+        /// Captures any pending changes in the DbContext
+        /// </summary>
+        /// <remarks>
+        /// Some triggers, like AfterSaveTriggers need help in knowing what has changed since by the time they are raised, the DbContext should have already committed all pending changes
+        /// Normally this is done by calling RaiseBeforeSaveTriggers prior to the DbContext committing on its changes however in case that is not possible, DiscoverChanges can be used to make a snapshot
+        /// </remarks>
+        void DiscoverChanges();
+        /// <summary>
+        /// Makes a snapshot of all changes in the DbContext and invokes BeforeSaveTriggers recursively based on the recursive settings until all changes have been processed
+        /// </summary>
         Task RaiseBeforeSaveTriggers(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Invokes AfterSaveTriggers non-recursively. Calling this method expects that either RaiseBeforeSaveTriggers() or DiscoverChanges() has called
+        /// </summary>
+        /// <returns></returns>
         Task RaiseAfterSaveTriggers(CancellationToken cancellationToken = default);
     }
 }

--- a/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/EntityFrameworkCore.Triggered.Transactions.Abstractions.csproj
+++ b/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/EntityFrameworkCore.Triggered.Transactions.Abstractions.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>EntityFrameworkCore.Triggered.Transactions</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/EntityFrameworkCore.Triggered.Transactions.Abstractions.csproj
+++ b/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/EntityFrameworkCore.Triggered.Transactions.Abstractions.csproj
@@ -5,4 +5,8 @@
     <RootNamespace>EntityFrameworkCore.Triggered.Transactions</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\EntityFrameworkCore.Triggered.Abstractions\EntityFrameworkCore.Triggered.Abstractions.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IAfterCommitTrigger.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IAfterCommitTrigger.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EntityFrameworkCore.Triggered.Transactions
 {
-    public interface IAfterCommitTrigger
+    public interface IAfterCommitTrigger<in TEntity>
+        where TEntity : class
     {
-        
+        Task AfterCommit(ITriggerContext<TEntity> context, CancellationToken cancellationToken);
     }
 }

--- a/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IAfterCommitTrigger.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IAfterCommitTrigger.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EntityFrameworkCore.Triggered.Transactions
+{
+    public interface IAfterCommitTrigger
+    {
+        
+    }
+}

--- a/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IAfterRollbackTrigger.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IAfterRollbackTrigger.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EntityFrameworkCore.Triggered.Transactions
 {
-    public interface IAfterRollbackTrigger
+    public interface IAfterRollbackTrigger<in TEntity>
+        where TEntity : class
     {
-        
+        Task AfterRollback(ITriggerContext<TEntity> context, CancellationToken cancellationToken);
     }
 }

--- a/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IAfterRollbackTrigger.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IAfterRollbackTrigger.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EntityFrameworkCore.Triggered.Transactions
+{
+    public interface IAfterRollbackTrigger
+    {
+        
+    }
+}

--- a/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IBeforeCommitTrigger.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IBeforeCommitTrigger.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EntityFrameworkCore.Triggered.Transactions
+{
+    public interface IBeforeCommitTrigger
+    {
+        
+    }
+}

--- a/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IBeforeCommitTrigger.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IBeforeCommitTrigger.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EntityFrameworkCore.Triggered.Transactions
 {
-    public interface IBeforeCommitTrigger
+    public interface IBeforeCommitTrigger<in TEntity>
+        where TEntity : class
     {
-        
+        Task BeforeCommit(ITriggerContext<TEntity> context, CancellationToken cancellationToken);
     }
 }

--- a/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IBeforeRollbackTrigger.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IBeforeRollbackTrigger.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EntityFrameworkCore.Triggered.Transactions
 {
-    public interface IBeforeRollbackTrigger
+    public interface IBeforeRollbackTrigger<in TEntity>
+        where TEntity : class
     {
-        
+        Task BeforeRollback(ITriggerContext<TEntity> context, CancellationToken cancellationToken);
     }
 }

--- a/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IBeforeRollbackTrigger.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions.Abstractions/IBeforeRollbackTrigger.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EntityFrameworkCore.Triggered.Transactions
+{
+    public interface IBeforeRollbackTrigger
+    {
+        
+    }
+}

--- a/src/EntityFrameworkCore.Triggered.Transactions/EntityFrameworkCore.Triggered.Transactions.csproj
+++ b/src/EntityFrameworkCore.Triggered.Transactions/EntityFrameworkCore.Triggered.Transactions.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EntityFrameworkCore.Triggered.Transactions.Abstractions\EntityFrameworkCore.Triggered.Transactions.Abstractions.csproj" />
+    <ProjectReference Include="..\EntityFrameworkCore.Triggered\EntityFrameworkCore.Triggered.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/EntityFrameworkCore.Triggered.Transactions/GlobalSuppressions.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "False warning", Scope = "namespaceanddescendants", Target = "EntityFrameworkCore.Triggered")]
+[assembly: SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "False warning", Scope = "namespaceanddescendants", Target = "EntityFrameworkCore.Triggered.Transactions.Internal")]

--- a/src/EntityFrameworkCore.Triggered.Transactions/Infrastructure/TriggersContextOptionsBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions/Infrastructure/TriggersContextOptionsBuilderExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Triggered.Infrastructure;
+
+namespace EntityFrameworkCore.Triggered.Transactions.Infrastructure
+{
+    public static class TriggersContextOptionsBuilderExtensions
+    {
+        public static TriggersContextOptionsBuilder UseTransactionTriggers(this TriggersContextOptionsBuilder triggersContextOptionsBuilder) 
+        {
+            if (triggersContextOptionsBuilder is null)
+            {
+                throw new ArgumentNullException(nameof(triggersContextOptionsBuilder));
+            }
+
+            return triggersContextOptionsBuilder
+                .AddTriggerType(typeof(IBeforeCommitTrigger<>))
+                .AddTriggerType(typeof(IAfterCommitTrigger<>))
+                .AddTriggerType(typeof(IBeforeRollbackTrigger<>))
+                .AddTriggerType(typeof(IAfterRollbackTrigger<>));
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Triggered.Transactions/Internal/AfterCommitTriggerAdapter.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions/Internal/AfterCommitTriggerAdapter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Triggered.Internal;
+
+namespace EntityFrameworkCore.Triggered.Transactions.Internal
+{
+    public class AfterCommitTriggerAdapter : TriggerAdapterBase
+    {
+        public AfterCommitTriggerAdapter(object trigger) : base(trigger)
+        {
+        }
+
+
+        public override Task Execute(object triggerContext, CancellationToken cancellationToken)
+            => Execute(nameof(IAfterCommitTrigger<object>.AfterCommit), triggerContext, cancellationToken);
+    }
+}

--- a/src/EntityFrameworkCore.Triggered.Transactions/Internal/AfterRollbackTriggerAdapter.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions/Internal/AfterRollbackTriggerAdapter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Triggered.Internal;
+
+namespace EntityFrameworkCore.Triggered.Transactions.Internal
+{
+    public class AfterRollbackTriggerAdapter : TriggerAdapterBase
+    {
+        public AfterRollbackTriggerAdapter(object trigger) : base(trigger)
+        {
+        }
+
+        public override Task Execute(object triggerContext, CancellationToken cancellationToken)
+            => Execute(nameof(IAfterRollbackTrigger<object>.AfterRollback), triggerContext, cancellationToken);
+    }
+}

--- a/src/EntityFrameworkCore.Triggered.Transactions/Internal/BeforeCommitTriggerAdapter.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions/Internal/BeforeCommitTriggerAdapter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Triggered.Internal;
+
+namespace EntityFrameworkCore.Triggered.Transactions.Internal
+{
+    public class BeforeCommitTriggerAdapter : TriggerAdapterBase
+    {
+        public BeforeCommitTriggerAdapter(object trigger) : base(trigger)
+        {
+        }
+
+        public override Task Execute(object triggerContext, CancellationToken cancellationToken)
+            => Execute(nameof(IBeforeCommitTrigger<object>.BeforeCommit), triggerContext, cancellationToken);
+    }
+}

--- a/src/EntityFrameworkCore.Triggered.Transactions/Internal/BeforeRollbackTriggerAdapter.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions/Internal/BeforeRollbackTriggerAdapter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Triggered.Internal;
+
+namespace EntityFrameworkCore.Triggered.Transactions.Internal
+{
+    public class BeforeRollbackTriggerAdapter : TriggerAdapterBase
+    {
+        public BeforeRollbackTriggerAdapter(object trigger) : base(trigger)
+        {
+        }
+
+        public override Task Execute(object triggerContext, CancellationToken cancellationToken)
+            => Execute(nameof(IBeforeRollbackTrigger<object>.BeforeRollback), triggerContext, cancellationToken);
+    }
+}

--- a/src/EntityFrameworkCore.Triggered.Transactions/TriggeredSessionExtensions.cs
+++ b/src/EntityFrameworkCore.Triggered.Transactions/TriggeredSessionExtensions.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Triggered.Internal;
+using EntityFrameworkCore.Triggered.Transactions;
+using EntityFrameworkCore.Triggered.Transactions.Internal;
+
+namespace EntityFrameworkCore.Triggered
+{
+    public static class TriggeredSessionExtensions
+    {
+        static ITriggerContextDiscoveryStrategy? _beforeCommitTriggerContextDiscoveryStrategy;
+        static ITriggerContextDiscoveryStrategy? _afterCommitTriggerContextDiscoveryStrategy;
+
+        static ITriggerContextDiscoveryStrategy? _beforeRollbackTriggerContextDiscoveryStrategy;
+        static ITriggerContextDiscoveryStrategy? _afterRollbackTriggerContextDiscoveryStrategy;
+
+        public static Task RaiseBeforeCommitTriggers(this ITriggerSession triggerSession, CancellationToken cancellationToken = default)
+        {
+            if (triggerSession == null)
+            {
+                throw new ArgumentNullException(nameof(triggerSession));
+            }
+
+            if (_beforeCommitTriggerContextDiscoveryStrategy == null)
+            {
+                _beforeCommitTriggerContextDiscoveryStrategy = new NonRecursiveTriggerContextDiscoveryStrategy("BeforeCommit", typeof(IBeforeCommitTrigger<>), trigger => new BeforeCommitTriggerAdapter(trigger));
+            }
+
+
+            return ((TriggerSession)triggerSession).RaiseTriggers(_beforeCommitTriggerContextDiscoveryStrategy, cancellationToken);
+        }
+
+        public static Task RaiseAfterCommitTriggers(this ITriggerSession triggerSession, CancellationToken cancellationToken = default)
+        {
+            if (triggerSession == null)
+            {
+                throw new ArgumentNullException(nameof(triggerSession));
+            }
+
+            if (_afterCommitTriggerContextDiscoveryStrategy == null)
+            {
+                _afterCommitTriggerContextDiscoveryStrategy = new NonRecursiveTriggerContextDiscoveryStrategy("AfterCommit", typeof(IAfterCommitTrigger<>), trigger => new AfterCommitTriggerAdapter(trigger));
+            }
+
+
+            return ((TriggerSession)triggerSession).RaiseTriggers(_afterCommitTriggerContextDiscoveryStrategy, cancellationToken);
+        }
+        public static Task RaiseBeforeRollbackTriggers(this ITriggerSession triggerSession, CancellationToken cancellationToken = default)
+        {
+            if (triggerSession == null)
+            {
+                throw new ArgumentNullException(nameof(triggerSession));
+            }
+
+            if (_beforeRollbackTriggerContextDiscoveryStrategy == null)
+            {
+                _beforeRollbackTriggerContextDiscoveryStrategy = new NonRecursiveTriggerContextDiscoveryStrategy("BeforeRollback", typeof(IBeforeRollbackTrigger<>), trigger => new BeforeRollbackTriggerAdapter(trigger));
+            }
+
+
+            return ((TriggerSession)triggerSession).RaiseTriggers(_beforeRollbackTriggerContextDiscoveryStrategy, cancellationToken);
+        }
+
+        public static Task RaiseAfterRollbackTriggers(this ITriggerSession triggerSession, CancellationToken cancellationToken = default)
+        {
+            if (triggerSession == null)
+            {
+                throw new ArgumentNullException(nameof(triggerSession));
+            }
+
+            if (_afterRollbackTriggerContextDiscoveryStrategy == null)
+            {
+                _afterRollbackTriggerContextDiscoveryStrategy = new NonRecursiveTriggerContextDiscoveryStrategy("AfterRollback", typeof(IAfterRollbackTrigger<>), trigger => new AfterRollbackTriggerAdapter(trigger));
+            }
+
+
+            return ((TriggerSession)triggerSession).RaiseTriggers(_afterRollbackTriggerContextDiscoveryStrategy, cancellationToken);
+        }
+
+    }
+}

--- a/src/EntityFrameworkCore.Triggered/Infrastructure/TriggersContextOptionsBuilder.cs
+++ b/src/EntityFrameworkCore.Triggered/Infrastructure/TriggersContextOptionsBuilder.cs
@@ -38,6 +38,9 @@ namespace EntityFrameworkCore.Triggered.Infrastructure
         public TriggersContextOptionsBuilder MaxRecusion(int maxRecursion = 100)
             => WithOption(e => e.WithMaxRecursion(maxRecursion));
 
+        public TriggersContextOptionsBuilder AddTriggerType(Type triggerType)
+            => WithOption(e => e.WithAdditionalTriggerType(triggerType));
+
         /// <summary>
         ///     Sets an option by cloning the extension used to store the settings. This ensures the builder
         ///     does not modify options that are already in use elsewhere.

--- a/src/EntityFrameworkCore.Triggered/Internal/ITriggerContextDiscoveryStrategy.cs
+++ b/src/EntityFrameworkCore.Triggered/Internal/ITriggerContextDiscoveryStrategy.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace EntityFrameworkCore.Triggered.Internal
+{
+    public interface ITriggerContextDiscoveryStrategy
+    {
+        IEnumerable<(TriggerAdapterBase triggerAdapter, ITriggerContextDescriptor triggerContextDescriptor)> Discover(TriggerOptions options, ITriggerRegistryService triggerRegistryService, TriggerContextTracker tracker, ILogger logger);
+    }
+}

--- a/src/EntityFrameworkCore.Triggered/Internal/NonRecursiveTriggerContextDiscoveryStrategy.cs
+++ b/src/EntityFrameworkCore.Triggered/Internal/NonRecursiveTriggerContextDiscoveryStrategy.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace EntityFrameworkCore.Triggered.Internal
+{
+    public class NonRecursiveTriggerContextDiscoveryStrategy : ITriggerContextDiscoveryStrategy
+    {
+        readonly string _name;
+        readonly Type _genericTriggerType;
+        readonly Func<object, TriggerAdapterBase> _triggerAdapterFactory;
+
+        public NonRecursiveTriggerContextDiscoveryStrategy(string name, Type genericTriggerType, Func<object, TriggerAdapterBase> triggerAdapterFactory)
+        {
+            _name = name ?? throw new ArgumentNullException(nameof(name));
+            _genericTriggerType = genericTriggerType ?? throw new ArgumentNullException(nameof(genericTriggerType));
+            _triggerAdapterFactory = triggerAdapterFactory ?? throw new ArgumentNullException(nameof(triggerAdapterFactory));
+        }
+
+        public IEnumerable<(TriggerAdapterBase triggerAdapter, ITriggerContextDescriptor triggerContextDescriptor)> Discover(TriggerOptions options, ITriggerRegistryService triggerRegistryService, TriggerContextTracker tracker, ILogger logger)
+        {
+            using (logger.BeginScope("Discovering {triggerType} triggers", _name))
+            {
+                var changes = tracker.DiscoveredChanges ?? throw new InvalidOperationException("Trigger discovery process has not yet started. Please ensure that TriggerSession.DiscoverChanges() or TriggerSession.RaiseBeforeSaveTriggers() has been called");
+
+                logger.LogInformation("Detected {changes} changes", changes.Count());
+
+                foreach (var triggerContextDescriptor in changes)
+                {
+                    var triggers = triggerRegistryService
+                        .GetRegistry(_genericTriggerType, _triggerAdapterFactory)
+                        .DiscoverTriggers(triggerContextDescriptor.EntityType)
+                        .ToList();
+
+                    logger.LogDebug("Discovered {triggers} triggers for change of type {entityType}", triggers.Count(), triggerContextDescriptor.EntityType);
+
+                    foreach (var trigger in triggers)
+                    {
+                        yield return (trigger, triggerContextDescriptor);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Triggered/Internal/RecursiveTriggerContextDiscoveryStrategy.cs
+++ b/src/EntityFrameworkCore.Triggered/Internal/RecursiveTriggerContextDiscoveryStrategy.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace EntityFrameworkCore.Triggered.Internal
+{
+    public class RecursiveTriggerContextDiscoveryStrategy : ITriggerContextDiscoveryStrategy
+    {
+        readonly string _name;
+        readonly Type _genericTriggerType;
+        readonly Func<object, TriggerAdapterBase> _triggerAdapterFactory;
+
+        public RecursiveTriggerContextDiscoveryStrategy(string name, Type genericTriggerType, Func<object, TriggerAdapterBase> triggerAdapterFactory)
+        {
+            _name = name ?? throw new ArgumentNullException(nameof(name));
+            _genericTriggerType = genericTriggerType ?? throw new ArgumentNullException(nameof(genericTriggerType));
+            _triggerAdapterFactory = triggerAdapterFactory ?? throw new ArgumentNullException(nameof(triggerAdapterFactory));
+        }
+
+        public IEnumerable<(TriggerAdapterBase triggerAdapter, ITriggerContextDescriptor triggerContextDescriptor)> Discover(TriggerOptions options, ITriggerRegistryService triggerRegistryService, TriggerContextTracker tracker, ILogger logger)
+        {
+            using (logger.BeginScope("Discovering {triggerType} triggers", _name))
+            {
+                var maxRecursion = options.MaxRecursion;
+
+                logger.LogDebug("Starting trigger discovery with a max recursion of {maxRecursion}", maxRecursion);
+
+                var iteration = 0;
+                while (true)
+                {
+                    if (iteration > maxRecursion)
+                    {
+                        throw new InvalidOperationException("MaxRecursion was reached");
+                    }
+
+
+                    IEnumerable<ITriggerContextDescriptor> changes;
+
+                    // In case someone made a call to TriggerSession.DetectChanges, prior to calling RaiseBeforeSaveTriggers, we want to make sure that we include that discovery result in the first iteration
+                    if (iteration == 0 && tracker.DiscoveredChanges != null)
+                    {
+                        // In case there are more yet undiscovered changes, make another call
+                        tracker.DiscoverChanges();
+                        changes = tracker.DiscoveredChanges!;
+                    }
+                    else
+                    {
+                        changes = tracker.DiscoverChanges().ToList();
+                    }
+
+                    if (changes.Any())
+                    {
+                        logger.LogInformation("({iteration}/{maxRecursion}): Detected {changes} changes", iteration, maxRecursion, changes.Count());
+
+                        foreach (var triggerContextDescriptor in changes)
+                        {
+                            var triggers = triggerRegistryService
+                                .GetRegistry(_genericTriggerType, _triggerAdapterFactory)
+                                .DiscoverTriggers(triggerContextDescriptor.EntityType)
+                                .ToList();
+
+                            logger.LogDebug("Discovered {triggers} triggers for change of type {entityType}", triggers.Count(), triggerContextDescriptor.EntityType);
+
+                            foreach (var trigger in triggers)
+                            {
+                                yield return (trigger, triggerContextDescriptor);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+
+                    iteration++;
+                }
+            }
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Triggered/Internal/TriggerAdapterBase.cs
+++ b/src/EntityFrameworkCore.Triggered/Internal/TriggerAdapterBase.cs
@@ -11,23 +11,23 @@ namespace EntityFrameworkCore.Triggered.Internal
 {
     public abstract class TriggerAdapterBase
     {
-        public TriggerAdapterBase(object changeHandler)
+        public TriggerAdapterBase(object trigger)
         {
-            if (changeHandler == null)
+            if (trigger == null)
             {
-                throw new ArgumentNullException(nameof(changeHandler));
+                throw new ArgumentNullException(nameof(trigger));
             }
 
-            Debug.Assert(TypeHelpers.FindGenericInterfaces(changeHandler.GetType(), typeof(IBeforeSaveTrigger<>)) != null);
+            Debug.Assert(TypeHelpers.FindGenericInterfaces(trigger.GetType(), typeof(IBeforeSaveTrigger<>)) != null);
 
-            ChangeHandler = changeHandler;
+            Trigger = trigger;
         }
 
-        protected object ChangeHandler { get; }
+        protected object Trigger { get; }
 
-        protected Task Execute(string methodName, object trigger, CancellationToken cancellationToken)
+        protected Task Execute(string methodName, object triggerContext, CancellationToken cancellationToken)
         {
-            var methodInfo = ChangeHandler
+            var methodInfo = Trigger
                 .GetType()
                 .GetMethod(methodName);
 
@@ -36,7 +36,7 @@ namespace EntityFrameworkCore.Triggered.Internal
                 throw new InvalidOperationException("No such method found");
             }
 
-            var result = (Task)methodInfo.Invoke(ChangeHandler, new object[] { trigger, cancellationToken });
+            var result = (Task)methodInfo.Invoke(Trigger, new object[] { triggerContext, cancellationToken });
 
             return result;
         }

--- a/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerAdapterStub.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerAdapterStub.cs
@@ -9,7 +9,6 @@ using EntityFrameworkCore.Triggered.Internal;
 
 namespace EntityFrameworkCore.Triggered.Tests.Stubs
 {
-    [ExcludeFromCodeCoverage]
     public class TriggerAdapterStub : TriggerAdapterBase
     {
         public TriggerAdapterStub(object changeHandler) : base(changeHandler)

--- a/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerContextStub.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerContextStub.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 
 namespace EntityFrameworkCore.Triggered.Tests.Stubs
 {
-    [ExcludeFromCodeCoverage]
     public class TriggerContextStub<TEntity> : ITriggerContext<TEntity>
         where TEntity : class
 

--- a/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerServiceStub.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerServiceStub.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.Triggered.Tests.Stubs
 {
-    [ExcludeFromCodeCoverage]
     public class TriggerServiceStub : ITriggerService
     {
         public int CreateSessionCalls;

--- a/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerSessionStub.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerSessionStub.cs
@@ -9,11 +9,15 @@ using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.Triggered.Tests.Stubs
 {
-    [ExcludeFromCodeCoverage]
     public class TriggerSessionStub : ITriggerSession
     {
         public int RaiseAfterSaveTriggersCalls;
         public int RaiseBeforeSaveTriggersCalls;
+
+        public void DiscoverChanges()
+        {
+
+        }
 
         public Task RaiseAfterSaveTriggers(CancellationToken cancellationToken = default)
         {

--- a/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerStub.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerStub.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 
 namespace EntityFrameworkCore.Triggered.Tests.Stubs
 {
-    [ExcludeFromCodeCoverage]
     public class TriggerStub<TEntity> : IBeforeSaveTrigger<TEntity>, IAfterSaveTrigger<TEntity>
         where TEntity: class
     {

--- a/test/EntityFrameworkCore.Triggered.Tests/TriggerSessionTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/TriggerSessionTests.cs
@@ -57,7 +57,7 @@ namespace EntityFrameworkCore.Triggered.Tests
             using var context = new TestDbContext();
             var subject = CreateSubject(context);
 
-            await subject.RaiseBeforeSaveTriggers();
+            subject.DiscoverChanges();
             await subject.RaiseAfterSaveTriggers();
 
             Assert.Empty(context.TriggerStub.AfterSaveInvocations);
@@ -106,7 +106,7 @@ namespace EntityFrameworkCore.Triggered.Tests
                 Name = "test1"
             });
 
-            await subject.RaiseBeforeSaveTriggers();
+            subject.DiscoverChanges();
             await subject.RaiseAfterSaveTriggers();
 
             Assert.Equal(1, context.TriggerStub.AfterSaveInvocations.Count);
@@ -139,10 +139,11 @@ namespace EntityFrameworkCore.Triggered.Tests
                 Name = "test1"
             });
 
+            subject.DiscoverChanges();
+            
             var cancellationTokenSource = new CancellationTokenSource();
-            await subject.RaiseBeforeSaveTriggers();
-
             cancellationTokenSource.Cancel();
+
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await subject.RaiseAfterSaveTriggers(cancellationTokenSource.Token));
         }
     }

--- a/test/EntityFrameworkCore.Triggered.Transactions.Tests/EntityFrameworkCore.Triggered.Transactions.Tests.csproj
+++ b/test/EntityFrameworkCore.Triggered.Transactions.Tests/EntityFrameworkCore.Triggered.Transactions.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EntityFrameworkCore.Triggered.Transactions\EntityFrameworkCore.Triggered.Transactions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/EntityFrameworkCore.Triggered.Transactions.Tests/Stubs/TriggerStub.cs
+++ b/test/EntityFrameworkCore.Triggered.Transactions.Tests/Stubs/TriggerStub.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EntityFrameworkCore.Triggered.Transactions.Tests.Stubs
+{
+    public class TriggerStub<TEntity> : IBeforeCommitTrigger<TEntity>, IAfterCommitTrigger<TEntity>, IBeforeRollbackTrigger<TEntity>, IAfterRollbackTrigger<TEntity>
+        where TEntity : class
+    {
+        public ICollection<ITriggerContext<TEntity>> BeforeCommitInvocations { get; } = new List<ITriggerContext<TEntity>>();
+        public ICollection<ITriggerContext<TEntity>> AfterCommitInvocations { get; } = new List<ITriggerContext<TEntity>>();
+        public ICollection<ITriggerContext<TEntity>> BeforeRollbackInvocations { get; } = new List<ITriggerContext<TEntity>>();
+        public ICollection<ITriggerContext<TEntity>> AfterRollbackInvocations { get; } = new List<ITriggerContext<TEntity>>();
+
+
+        public Task BeforeCommit(ITriggerContext<TEntity> context, CancellationToken cancellationToken)
+        {
+            BeforeCommitInvocations.Add(context);
+            return Task.CompletedTask;
+        }
+
+        public Task AfterCommit(ITriggerContext<TEntity> context, CancellationToken cancellationToken)
+        {
+            AfterCommitInvocations.Add(context);
+            return Task.CompletedTask;
+        }
+
+        public Task BeforeRollback(ITriggerContext<TEntity> context, CancellationToken cancellationToken)
+        {
+            BeforeRollbackInvocations.Add(context);
+            return Task.CompletedTask;
+        }
+
+        public Task AfterRollback(ITriggerContext<TEntity> context, CancellationToken cancellationToken)
+        {
+            AfterRollbackInvocations.Add(context);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/EntityFrameworkCore.Triggered.Transactions.Tests/TriggeredSessionExtensionsTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Transactions.Tests/TriggeredSessionExtensionsTests.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Triggered.Transactions.Infrastructure;
+using EntityFrameworkCore.Triggered.Transactions.Tests.Stubs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Xunit;
+
+namespace EntityFrameworkCore.Triggered.Transactions.Tests
+{
+    public class TriggeredSessionExtensionsTests
+    {
+        class TestModel
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        class TestDbContext : DbContext
+        {
+            public TriggerStub<TestModel> TriggerStub { get; } = new TriggerStub<TestModel>();
+
+            public DbSet<TestModel> TestModels { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                base.OnConfiguring(optionsBuilder);
+
+                optionsBuilder.UseInMemoryDatabase("test");
+                optionsBuilder.UseTriggers(triggerOptions => {
+                    triggerOptions
+                        .UseTransactionTriggers()
+                        .AddTrigger(TriggerStub);
+                });
+            }
+        }
+
+        protected ITriggerSession CreateSession(DbContext context)
+            => context.Database.GetService<ITriggerService>().CreateSession(context);
+
+
+        [Fact]
+        public async Task RaiseBeforeCommitTriggers_RaisesNothingOnNoChanges()
+        {
+            using var context = new TestDbContext();
+            var session = CreateSession(context);
+
+            session.DiscoverChanges();
+            await session.RaiseBeforeCommitTriggers();
+
+            Assert.Empty(context.TriggerStub.BeforeCommitInvocations);
+        }
+
+        [Fact]
+        public async Task RaiseBeforeCommitTriggers_RaisesOnceOnSimpleAddition()
+        {
+            using var context = new TestDbContext();
+            var session = CreateSession(context);
+
+            context.TestModels.Add(new TestModel {
+                Id = Guid.NewGuid(),
+                Name = "test1"
+            });
+
+            session.DiscoverChanges();
+            await session.RaiseBeforeCommitTriggers();
+
+            Assert.Equal(1, context.TriggerStub.BeforeCommitInvocations.Count);
+        }
+
+        [Fact]
+        public async Task RaiseAfterCommitTriggers_RaisesNothingOnNoChanges()
+        {
+            using var context = new TestDbContext();
+            var session = CreateSession(context);
+
+            session.DiscoverChanges();
+            await session.RaiseAfterCommitTriggers();
+
+            Assert.Empty(context.TriggerStub.AfterCommitInvocations);
+        }
+
+        [Fact]
+        public async Task RaiseAfterCommitTriggers_RaisesOnceOnSimpleAddition()
+        {
+            using var context = new TestDbContext();
+            var session = CreateSession(context);
+
+            context.TestModels.Add(new TestModel {
+                Id = Guid.NewGuid(),
+                Name = "test1"
+            });
+
+            session.DiscoverChanges();
+            await session.RaiseAfterCommitTriggers();
+
+            Assert.Equal(1, context.TriggerStub.AfterCommitInvocations.Count);
+        }
+
+
+        [Fact]
+        public async Task RaiseBeforeRollbackTriggers_RaisesNothingOnNoChanges()
+        {
+            using var context = new TestDbContext();
+            var session = CreateSession(context);
+
+            session.DiscoverChanges();
+            await session.RaiseBeforeRollbackTriggers();
+
+            Assert.Empty(context.TriggerStub.BeforeRollbackInvocations);
+        }
+
+        [Fact]
+        public async Task RaiseBeforeRollbackTriggers_RaisesOnceOnSimpleAddition()
+        {
+            using var context = new TestDbContext();
+            var session = CreateSession(context);
+
+            context.TestModels.Add(new TestModel {
+                Id = Guid.NewGuid(),
+                Name = "test1"
+            });
+
+            session.DiscoverChanges();
+            await session.RaiseBeforeRollbackTriggers();
+
+            Assert.Equal(1, context.TriggerStub.BeforeRollbackInvocations.Count);
+        }
+
+
+        [Fact]
+        public async Task RaiseAfterRollbackTriggers_RaisesNothingOnNoChanges()
+        {
+            using var context = new TestDbContext();
+            var session = CreateSession(context);
+
+            session.DiscoverChanges();
+            await session.RaiseAfterRollbackTriggers();
+
+            Assert.Empty(context.TriggerStub.AfterRollbackInvocations);
+        }
+
+        [Fact]
+        public async Task RaiseAfterRollbackTriggers_RaisesOnceOnSimpleAddition()
+        {
+            using var context = new TestDbContext();
+            var session = CreateSession(context);
+
+            context.TestModels.Add(new TestModel {
+                Id = Guid.NewGuid(),
+                Name = "test1"
+            });
+
+            session.DiscoverChanges();
+            await session.RaiseAfterRollbackTriggers();
+
+            Assert.Equal(1, context.TriggerStub.AfterRollbackInvocations.Count);
+        }
+
+
+    }
+}


### PR DESCRIPTION
This adds support for adding custom trigger types with a first implementation for supporting transaction triggers (IBeforeCommitTrigger, IAfterCommitTrigger, IBeforeRollbackTrigger, IAfterRollbackTrigger)