### PR TITLE
Ability to capture the current ServiceProvider when resolving DbContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ public class Startup
     {
         services.AddSingleton<EmailService>();
         services
-            .AddDbContext<ApplicationContext>()
+            .AddTriggeredDbContext<ApplicationContext>()
             .AddScoped<IBeforeSaveTrigger<Course>, BeforeSaveStudentTrigger>()
     }
 

--- a/src/EntityFrameworkCore.Triggered/Extensions/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Triggered/Extensions/ServiceCollectionExtensions.cs
@@ -40,5 +40,17 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return serviceCollection;
         }
+
+        public static IServiceCollection AddTriggeredDbContextPool<TContext>(this IServiceCollection serviceCollection, Action<DbContextOptionsBuilder>? optionsAction = null, int poolSize = 128) where TContext : DbContext
+        {
+
+            serviceCollection.AddDbContextPool<TContext>(options => {
+                optionsAction?.Invoke(options);
+                options.UseTriggers();
+            }, poolSize);
+
+
+            return serviceCollection;
+        }
     }
 }

--- a/src/EntityFrameworkCore.Triggered/Extensions/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Triggered/Extensions/ServiceCollectionExtensions.cs
@@ -26,6 +26,20 @@ namespace Microsoft.Extensions.DependencyInjection
             return instance;
         }
 
+        private static object SetApplicationTriggerServiceProviderAccessor(object instance, IServiceProvider serviceProvider)
+        {
+            if (instance is DbContext dbContext)
+            {
+                var applicationTriggerServiceProviderAccessor = dbContext.GetService<ApplicationTriggerServiceProviderAccessor>();
+                if (applicationTriggerServiceProviderAccessor != null)
+                {
+                    applicationTriggerServiceProviderAccessor.SetTriggerServiceProvider(serviceProvider);
+                }
+            }
+
+            return instance;
+        }
+
         public static IServiceCollection AddTriggeredDbContext<TContext>(this IServiceCollection serviceCollection, Action<DbContextOptionsBuilder>? optionsAction = null, ServiceLifetime contextLifetime = ServiceLifetime.Scoped, ServiceLifetime optionsLifetime = ServiceLifetime.Scoped) where TContext : DbContext
         {
             serviceCollection.TryAdd(ServiceDescriptor.Describe(
@@ -43,12 +57,20 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddTriggeredDbContextPool<TContext>(this IServiceCollection serviceCollection, Action<DbContextOptionsBuilder>? optionsAction = null, int poolSize = 128) where TContext : DbContext
         {
-
             serviceCollection.AddDbContextPool<TContext>(options => {
                 optionsAction?.Invoke(options);
                 options.UseTriggers();
             }, poolSize);
 
+            var serviceDescriptor = serviceCollection.FirstOrDefault(x => x.ServiceType == typeof(TContext));
+            if (serviceDescriptor?.ImplementationFactory != null)
+            {
+                serviceCollection.Replace(ServiceDescriptor.Describe(
+                    serviceType: typeof(TContext),
+                    implementationFactory: serviceProvider => SetApplicationTriggerServiceProviderAccessor(serviceDescriptor.ImplementationFactory(serviceProvider), serviceProvider),
+                    lifetime: ServiceLifetime.Scoped
+                ));
+            }
 
             return serviceCollection;
         }

--- a/src/EntityFrameworkCore.Triggered/Extensions/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Triggered/Extensions/ServiceCollectionExtensions.cs
@@ -1,32 +1,44 @@
 ﻿using System;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using EntityFrameworkCore.Triggered.Internal;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceCollectionExtensions
     {
+        private static object CreateContextFactory(IServiceProvider serviceProvider, Type contextType)
+        {
+            var instance = ActivatorUtilities.CreateInstance(serviceProvider, contextType);
+
+            if (instance is DbContext dbContextInstance)
+            {
+                var applicationTriggerServiceProviderAccessor = dbContextInstance.GetService<ApplicationTriggerServiceProviderAccessor>();
+                if (applicationTriggerServiceProviderAccessor != null)
+                {
+                    applicationTriggerServiceProviderAccessor.SetTriggerServiceProvider(serviceProvider);
+                }
+            }
+
+            return instance;
+        }
+
         public static IServiceCollection AddTriggeredDbContext<TContext>(this IServiceCollection serviceCollection, Action<DbContextOptionsBuilder>? optionsAction = null, ServiceLifetime contextLifetime = ServiceLifetime.Scoped, ServiceLifetime optionsLifetime = ServiceLifetime.Scoped) where TContext : DbContext
         {
-            var serviceCollections = serviceCollection.AddDbContext<TContext>(options => {
+            serviceCollection.TryAdd(ServiceDescriptor.Describe(
+                serviceType: typeof(TContext),
+                implementationFactory: serviceProvider => CreateContextFactory(serviceProvider, typeof(TContext)),
+                lifetime: contextLifetime));
+
+            serviceCollection.AddDbContext<TContext>(options => {
                 optionsAction?.Invoke(options);
                 options.UseTriggers();
             }, contextLifetime, optionsLifetime);
 
-
             return serviceCollection;
         }
-
-        public static IServiceCollection AddTriggeredDbContextPool<TContext>(this IServiceCollection serviceCollection, Action<DbContextOptionsBuilder>? optionsAction = null, int poolSize = 128) where TContext : DbContext
-        {
-
-            serviceCollection.AddDbContextPool<TContext>(options => {
-                optionsAction?.Invoke(options);
-                options.UseTriggers();
-            }, poolSize);
-
-
-            return serviceCollection;
-        }
-
     }
 }

--- a/src/EntityFrameworkCore.Triggered/Internal/ApplicationTriggerServiceProviderAccessor.cs
+++ b/src/EntityFrameworkCore.Triggered/Internal/ApplicationTriggerServiceProviderAccessor.cs
@@ -28,6 +28,16 @@ namespace EntityFrameworkCore.Triggered.Internal
             _scopedServiceProviderTransform = scopedServiceProviderTransform;
         }
 
+        public void SetTriggerServiceProvider(IServiceProvider serviceProvider)
+        {
+            if (_applicationScopedServiceProvider != null)
+            {
+                throw new InvalidOperationException("Can only set applicationScopedServiceProvider once");
+            }
+
+            _applicationScopedServiceProvider = serviceProvider;
+        }
+
         public IServiceProvider GetTriggerServiceProvider()
         {
             if (_applicationScopedServiceProvider == null)

--- a/test/EntityFrameworkCore.Triggered.Tests/Infrastructure/ServiceCollectionExtensionsTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Infrastructure/ServiceCollectionExtensionsTests.cs
@@ -79,29 +79,5 @@ namespace EntityFrameworkCore.Triggered.Tests.Infrastructure
             Assert.NotNull(triggerStub);
             Assert.Equal(1, triggerStub.BeforeSaveInvocations.Count);
         }
-
-        [Fact]
-        public void AddTriggeredDbContextPool_ReusesScopedServiceProvider()
-        {
-            var subject = new ServiceCollection();
-            subject.AddTriggeredDbContextPool<TestDbContext>(options => {
-                options.UseInMemoryDatabase("test");
-                options.EnableServiceProviderCaching(false);
-            }).AddScoped<IBeforeSaveTrigger<TestModel>, TriggerStub<TestModel>>();
-
-            var serviceProvider = subject.BuildServiceProvider();
-
-            using var scope = serviceProvider.CreateScope();
-
-            var context = scope.ServiceProvider.GetRequiredService<TestDbContext>();
-            context.TestModels.Add(new TestModel());
-
-            context.SaveChanges();
-
-            var triggerStub = scope.ServiceProvider.GetRequiredService<IBeforeSaveTrigger<TestModel>>() as TriggerStub<TestModel>;
-            Assert.NotNull(triggerStub);
-            Assert.Equal(1, triggerStub.BeforeSaveInvocations.Count);
-        }
-
     }
 }

--- a/test/EntityFrameworkCore.Triggered.Tests/Infrastructure/ServiceCollectionExtensionsTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Infrastructure/ServiceCollectionExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using EntityFrameworkCore.Triggered.Tests.Stubs;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -7,10 +8,13 @@ namespace EntityFrameworkCore.Triggered.Tests.Infrastructure
 {
     public class ServiceCollectionExtensionsTests
     {
+        class TestModel { public int Id { get; set; } }
 #pragma warning disable CS0618 // Type or member is obsolete
         class TestDbContext : TriggeredDbContext
 #pragma warning restore CS0618 // Type or member is obsolete
         {
+
+            public DbSet<TestModel> TestModels { get; set; }
             public TestDbContext(DbContextOptions options) : base(options)
             {
             }
@@ -51,5 +55,53 @@ namespace EntityFrameworkCore.Triggered.Tests.Infrastructure
             Assert.True(optionsActionsCalled);
             Assert.NotNull(context.GetService<ITriggerService>());
         }
+
+
+        [Fact]
+        public void AddTriggeredDbContext_ReusesScopedServiceProvider()
+        {
+            var subject = new ServiceCollection();
+            subject.AddTriggeredDbContext<TestDbContext>(options => {
+                options.UseInMemoryDatabase("test");
+                options.EnableServiceProviderCaching(false);
+            }).AddScoped<IBeforeSaveTrigger<TestModel>, TriggerStub<TestModel>>();
+
+            var serviceProvider = subject.BuildServiceProvider();
+
+            using var scope = serviceProvider.CreateScope();
+
+            var context = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+            context.TestModels.Add(new TestModel());
+
+            context.SaveChanges();
+
+            var triggerStub = scope.ServiceProvider.GetRequiredService<IBeforeSaveTrigger<TestModel>>() as TriggerStub<TestModel>;
+            Assert.NotNull(triggerStub);
+            Assert.Equal(1, triggerStub.BeforeSaveInvocations.Count);
+        }
+
+        [Fact]
+        public void AddTriggeredDbContextPool_ReusesScopedServiceProvider()
+        {
+            var subject = new ServiceCollection();
+            subject.AddTriggeredDbContextPool<TestDbContext>(options => {
+                options.UseInMemoryDatabase("test");
+                options.EnableServiceProviderCaching(false);
+            }).AddScoped<IBeforeSaveTrigger<TestModel>, TriggerStub<TestModel>>();
+
+            var serviceProvider = subject.BuildServiceProvider();
+
+            using var scope = serviceProvider.CreateScope();
+
+            var context = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+            context.TestModels.Add(new TestModel());
+
+            context.SaveChanges();
+
+            var triggerStub = scope.ServiceProvider.GetRequiredService<IBeforeSaveTrigger<TestModel>>() as TriggerStub<TestModel>;
+            Assert.NotNull(triggerStub);
+            Assert.Equal(1, triggerStub.BeforeSaveInvocations.Count);
+        }
+
     }
 }

--- a/test/EntityFrameworkCore.Triggered.Tests/Internal/ApplicationTriggerServiceProviderAccessorTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Internal/ApplicationTriggerServiceProviderAccessorTests.cs
@@ -96,15 +96,22 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
         [Fact]
         public void GetTriggerServiceProvider_WithExplicitlySetServiceProvider_ReturnsSetServiceProvider()
         {
-            var internalServiceProviderStub = new ServiceCollection().BuildServiceProvider();
-            var applicationServiceProviderStub = new ServiceCollection().BuildServiceProvider();
+            var applicationServiceProvider = new ServiceCollection()
+                .AddDbContext<TestDbContext>(options => {
+                    options.UseInMemoryDatabase("Test")
+                           .UseTriggers();
+                })
+                .AddScoped<object>()
+                .BuildServiceProvider();
 
-            var subject = new ApplicationTriggerServiceProviderAccessor(internalServiceProviderStub, null);
-            subject.SetTriggerServiceProvider(applicationServiceProviderStub);
+            var internalServiceProviderStub = new ServiceCollection().BuildServiceProvider();
+
+            var subject = applicationServiceProvider.GetRequiredService<TestDbContext>().GetService<ApplicationTriggerServiceProviderAccessor>();
+            subject.SetTriggerServiceProvider(applicationServiceProvider);
             
             var triggerServiceProvider = subject.GetTriggerServiceProvider();
 
-            Assert.Equal(applicationServiceProviderStub, triggerServiceProvider);
+            Assert.Equal(applicationServiceProvider, triggerServiceProvider);
 
         }
     }

--- a/test/EntityFrameworkCore.Triggered.Tests/Internal/ApplicationTriggerServiceProviderAccessorTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Internal/ApplicationTriggerServiceProviderAccessorTests.cs
@@ -91,6 +91,20 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
             var triggerServiceProvider = subject.GetTriggerServiceProvider();
 
             Assert.Equal(applicationServiceProvider, triggerServiceProvider);
+        }
+
+        [Fact]
+        public void GetTriggerServiceProvider_WithExplicitlySetServiceProvider_ReturnsSetServiceProvider()
+        {
+            var internalServiceProviderStub = new ServiceCollection().BuildServiceProvider();
+            var applicationServiceProviderStub = new ServiceCollection().BuildServiceProvider();
+
+            var subject = new ApplicationTriggerServiceProviderAccessor(internalServiceProviderStub, null);
+            subject.SetTriggerServiceProvider(applicationServiceProviderStub);
+            
+            var triggerServiceProvider = subject.GetTriggerServiceProvider();
+
+            Assert.Equal(applicationServiceProviderStub, triggerServiceProvider);
 
         }
     }


### PR DESCRIPTION
This only works when using AddTriggeredDbContext but its a start