### PR TITLE
Removed unneeded complexities

### DIFF
--- a/test/EntityFrameworkCore.Triggered.Tests/Internal/ApplicationTriggerServiceProviderAccessorTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Internal/ApplicationTriggerServiceProviderAccessorTests.cs
@@ -52,32 +52,6 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
         }
 
         [Fact]
-        public void GetTriggerServiceProvider_WithApplicationDi_ReturnsScopedApplication()
-        {
-            var applicationServiceProvider = new ServiceCollection()
-                .AddDbContext<TestDbContext>(options => {
-                    options.UseInMemoryDatabase("Test")
-                           .UseTriggers();
-                    
-                    options.EnableServiceProviderCaching(false);
-                })
-                .AddScoped<object>()
-                .BuildServiceProvider();
-
-            var dbContext = applicationServiceProvider.GetRequiredService<TestDbContext>();
-
-            var subject = new ApplicationTriggerServiceProviderAccessor(dbContext.GetInfrastructure(), null, new NullLogger<ApplicationTriggerServiceProviderAccessor>());
-            var triggerServiceProvider = subject.GetTriggerServiceProvider();
-
-            var scopedObject = triggerServiceProvider.GetService<object>();
-            Assert.NotNull(scopedObject);
-
-            var applicationScopedObject = applicationServiceProvider.GetService<object>();
-            Assert.NotNull(applicationScopedObject);
-            Assert.NotEqual(applicationScopedObject, scopedObject);
-        }
-
-        [Fact]
         public void GetTriggerServiceProvider_WithApplicationDiAndTransform_ReturnsCustomServiceProvider()
         {
             var applicationServiceProvider = new ServiceCollection()

--- a/test/EntityFrameworkCore.Triggered.Tests/TriggerServiceApplicationDependenciesTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/TriggerServiceApplicationDependenciesTests.cs
@@ -35,15 +35,19 @@ namespace EntityFrameworkCore.Triggered.Tests
                 .AddScoped<IBeforeSaveTrigger<TestModel>, Stubs.TriggerStub<TestModel>>()
                 .BuildServiceProvider();
 
-            using var serviceScope = applicationServiceProvider.CreateScope();
-            var dbContext = serviceScope.ServiceProvider.GetRequiredService<TestDbContext>();
+            void SimulateRequest()
+            {
+                using var serviceScope = applicationServiceProvider.CreateScope();
+                var dbContext = serviceScope.ServiceProvider.GetRequiredService<TestDbContext>();
+                var triggerStub = serviceScope.ServiceProvider.GetRequiredService<IBeforeSaveTrigger<TestModel>>() as TriggerStub<TestModel>;
+                Assert.Equal(0, triggerStub.BeforeSaveInvocations.Count);
+                
+                dbContext.Add(new TestModel { });
+                dbContext.SaveChanges();
+            }
 
-            dbContext.Add(new TestModel { });
-            dbContext.SaveChanges();
-
-            var triggerStub = serviceScope.ServiceProvider.GetRequiredService<IBeforeSaveTrigger<TestModel>>() as TriggerStub<TestModel>;
-
-            Assert.Equal(0, triggerStub.BeforeSaveInvocations.Count);
+            SimulateRequest();
+            SimulateRequest();
         }
 
         [Fact]


### PR DESCRIPTION
There is no need to explicitly inject the scoped application service provider when its using AddDbContext or AddDbContext factory, removed it.

As discussed in https://github.com/dotnet/efcore/issues/23559