### PR TITLE
Trigger service configuration

### DIFF
--- a/src/EntityFrameworkCore.Triggered.Abstractions/Internal/IsExternalInit.cs
+++ b/src/EntityFrameworkCore.Triggered.Abstractions/Internal/IsExternalInit.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET45 || NET451 || NET452 || NET6 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+
+using System.ComponentModel;
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}
+
+#endif

--- a/src/EntityFrameworkCore.Triggered.Abstractions/TriggerConfiguration.cs
+++ b/src/EntityFrameworkCore.Triggered.Abstractions/TriggerConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EntityFrameworkCore.Triggered
+{
+    public record TriggerConfiguration
+    {
+        public TriggerConfiguration(bool disabled, int maxCascadeCycles)
+        {
+            Disabled = disabled;
+            MaxCascadeCycles = maxCascadeCycles;
+        }
+
+        public bool Disabled { get; init; }
+
+        public int MaxCascadeCycles { get; init; }
+    }
+}

--- a/src/EntityFrameworkCore.Triggered/Extensions/DbContextExtensions.cs
+++ b/src/EntityFrameworkCore.Triggered/Extensions/DbContextExtensions.cs
@@ -8,6 +8,9 @@ namespace EntityFrameworkCore.Triggered.Extensions
 {
     public static class DbContextExtensions
     {
+        /// <summary>
+        /// Gets the <c>ITriggerService</c> that is used to create trigger sessions.Allows for just in time configuration
+        /// </summary>
         public static ITriggerService GetTriggerService(this DbContext dbContext)
         {
             if (dbContext is null)
@@ -18,6 +21,9 @@ namespace EntityFrameworkCore.Triggered.Extensions
             return dbContext.GetService<ITriggerService>() ?? throw new InvalidOperationException("Triggers are not configured for this DbContext");
         }
 
+        /// <summary>
+        /// Gets or creates a <c>ITriggerSession</c> that can be used to manually invoke triggers
+        /// </summary>
         public static ITriggerSession CreateTriggerSession(this DbContext dbContext, IServiceProvider? serviceProvider = null)
         {
             var triggerService = GetTriggerService(dbContext);
@@ -25,6 +31,9 @@ namespace EntityFrameworkCore.Triggered.Extensions
             return triggerService.CreateSession(dbContext, serviceProvider);
         }
 
+        /// <summary>
+        /// Calls dbContext.SaveChanges without invoking triggers
+        /// </summary>
         public static int SaveChangesWithoutTriggers(this DbContext dbContext, bool acceptAllChangesOnSuccess = true)
         {
             var triggerService = GetTriggerService(dbContext);
@@ -42,9 +51,15 @@ namespace EntityFrameworkCore.Triggered.Extensions
             }
         }
 
+        /// <summary>
+        /// Calls dbContext.SaveChanges without invoking triggers
+        /// </summary>
         public static Task<int> SaveChangesWithoutTriggersAsync(this DbContext dbContext, CancellationToken cancellationToken = default)
             => SaveChangesWithoutTriggersAsync(dbContext, true, cancellationToken);
 
+        /// <summary>
+        /// Calls dbContext.SaveChanges without invoking triggers
+        /// </summary>
         public static Task<int> SaveChangesWithoutTriggersAsync(this DbContext dbContext, bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
         {
             var triggerService = GetTriggerService(dbContext);

--- a/src/EntityFrameworkCore.Triggered/Extensions/DbContextExtensions.cs
+++ b/src/EntityFrameworkCore.Triggered/Extensions/DbContextExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
@@ -6,11 +8,58 @@ namespace EntityFrameworkCore.Triggered.Extensions
 {
     public static class DbContextExtensions
     {
+        public static ITriggerService GetTriggerService(this DbContext dbContext)
+        {
+            if (dbContext is null)
+            {
+                throw new ArgumentNullException(nameof(dbContext));
+            }
+
+            return dbContext.GetService<ITriggerService>() ?? throw new InvalidOperationException("Triggers are not configured for this DbContext");
+        }
+
         public static ITriggerSession CreateTriggerSession(this DbContext dbContext, IServiceProvider? serviceProvider = null)
         {
-            var triggerService = dbContext.GetService<ITriggerService>() ?? throw new InvalidOperationException("Trigger service infrastructure is not configured");
+            var triggerService = GetTriggerService(dbContext);
 
             return triggerService.CreateSession(dbContext, serviceProvider);
+        }
+
+        public static int SaveChangesWithoutTriggers(this DbContext dbContext, bool acceptAllChangesOnSuccess = true)
+        {
+            var triggerService = GetTriggerService(dbContext);
+            var initialConfiguration = triggerService.Configuration;
+
+            try
+            {
+                triggerService.Configuration = initialConfiguration with { Disabled = true };
+
+                return dbContext.SaveChanges(acceptAllChangesOnSuccess);
+            }
+            finally
+            {
+                triggerService.Configuration = initialConfiguration;
+            }
+        }
+
+        public static Task<int> SaveChangesWithoutTriggersAsync(this DbContext dbContext, CancellationToken cancellationToken = default)
+            => SaveChangesWithoutTriggersAsync(dbContext, true, cancellationToken);
+
+        public static Task<int> SaveChangesWithoutTriggersAsync(this DbContext dbContext, bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+        {
+            var triggerService = GetTriggerService(dbContext);
+            var initialConfiguration = triggerService.Configuration;
+
+            try
+            {
+                triggerService.Configuration = initialConfiguration with { Disabled = true };
+
+                return dbContext.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+            }
+            finally
+            {
+                triggerService.Configuration = initialConfiguration;
+            }
         }
     }
 }

--- a/src/EntityFrameworkCore.Triggered/ITriggerService.cs
+++ b/src/EntityFrameworkCore.Triggered/ITriggerService.cs
@@ -5,6 +5,8 @@ namespace EntityFrameworkCore.Triggered
 {
     public interface ITriggerService
     {
+        TriggerConfiguration Configuration { get; set; }
+
         ITriggerSession CreateSession(DbContext context, IServiceProvider? serviceProvider = null);
 
         ITriggerSession? Current { get; set; }

--- a/src/EntityFrameworkCore.Triggered/Internal/CascadingTriggerContextDiscoveryStrategy.cs
+++ b/src/EntityFrameworkCore.Triggered/Internal/CascadingTriggerContextDiscoveryStrategy.cs
@@ -26,9 +26,9 @@ namespace EntityFrameworkCore.Triggered.Internal
             _skipDetectedChanges = skipDetectedChanges;
         }
 
-        public IEnumerable<IEnumerable<TriggerContextDescriptor>> Discover(TriggerOptions options, TriggerContextTracker tracker, ILogger logger)
+        public IEnumerable<IEnumerable<TriggerContextDescriptor>> Discover(TriggerConfiguration configuration, TriggerContextTracker tracker, ILogger logger)
         {
-            var maxCascadingCycles = options.MaxCascadeCycles;
+            var maxCascadingCycles = configuration.MaxCascadeCycles;
             _discoveryStarted(logger, _name, maxCascadingCycles, null);
 
             var iteration = 0;

--- a/src/EntityFrameworkCore.Triggered/Internal/ITriggerContextDiscoveryStrategy.cs
+++ b/src/EntityFrameworkCore.Triggered/Internal/ITriggerContextDiscoveryStrategy.cs
@@ -5,6 +5,6 @@ namespace EntityFrameworkCore.Triggered.Internal
 {
     public interface ITriggerContextDiscoveryStrategy
     {
-        IEnumerable<IEnumerable<TriggerContextDescriptor>> Discover(TriggerOptions options, TriggerContextTracker tracker, ILogger logger);
+        IEnumerable<IEnumerable<TriggerContextDescriptor>> Discover(TriggerConfiguration configuration, TriggerContextTracker tracker, ILogger logger);
     }
 }

--- a/src/EntityFrameworkCore.Triggered/Internal/NonCascadingTriggerContextDiscoveryStrategy.cs
+++ b/src/EntityFrameworkCore.Triggered/Internal/NonCascadingTriggerContextDiscoveryStrategy.cs
@@ -19,7 +19,7 @@ namespace EntityFrameworkCore.Triggered.Internal
             _name = name ?? throw new ArgumentNullException(nameof(name));
         }
 
-        public IEnumerable<IEnumerable<TriggerContextDescriptor>> Discover(TriggerOptions options, TriggerContextTracker tracker, ILogger logger)
+        public IEnumerable<IEnumerable<TriggerContextDescriptor>> Discover(TriggerConfiguration configuration, TriggerContextTracker tracker, ILogger logger)
         {
             var changes = tracker.DiscoveredChanges ?? throw new InvalidOperationException("Trigger discovery process has not yet started. Please ensure that TriggerSession.DiscoverChanges() or TriggerSession.RaiseBeforeSaveTriggers() has been called");
 

--- a/src/EntityFrameworkCore.Triggered/TriggerSession.cs
+++ b/src/EntityFrameworkCore.Triggered/TriggerSession.cs
@@ -17,17 +17,17 @@ namespace EntityFrameworkCore.Triggered
         static ITriggerContextDiscoveryStrategy? _afterSaveFailedTriggerContextDiscoveryStrategy;
 
         readonly ITriggerService _triggerService;
-        readonly TriggerOptions _options;
+        readonly TriggerConfiguration _configuration;
         readonly ITriggerDiscoveryService _triggerDiscoveryService;
         readonly TriggerContextTracker _tracker;
         readonly ILogger<TriggerSession> _logger;
 
         bool _raiseBeforeSaveTriggersCalled;
 
-        public TriggerSession(ITriggerService triggerService, TriggerOptions options, ITriggerDiscoveryService triggerDiscoveryService, TriggerContextTracker tracker, ILogger<TriggerSession> logger)
+        public TriggerSession(ITriggerService triggerService, TriggerConfiguration configuration, ITriggerDiscoveryService triggerDiscoveryService, TriggerContextTracker tracker, ILogger<TriggerSession> logger)
         {
             _triggerService = triggerService ?? throw new ArgumentNullException(nameof(triggerService));
-            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _triggerDiscoveryService = triggerDiscoveryService ?? throw new ArgumentNullException(nameof(triggerDiscoveryService));
             _tracker = tracker ?? throw new ArgumentNullException(nameof(tracker));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -50,7 +50,7 @@ namespace EntityFrameworkCore.Triggered
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var triggerContextDescriptorBatches = triggerContextDiscoveryStrategy.Discover(_options, _tracker, _logger);
+            var triggerContextDescriptorBatches = triggerContextDiscoveryStrategy.Discover(_configuration, _tracker, _logger);
             foreach (var triggerContextDescriptorBatch in triggerContextDescriptorBatches)
             {
                 List<(TriggerContextDescriptor triggerContextDescriptor, TriggerDescriptor triggerDescriptor)>? triggerInvocations = null;

--- a/src/EntityFrameworkCore.Triggered/TriggerSession.cs
+++ b/src/EntityFrameworkCore.Triggered/TriggerSession.cs
@@ -48,6 +48,11 @@ namespace EntityFrameworkCore.Triggered
                 throw new ArgumentNullException(nameof(triggerContextDiscoveryStrategy));
             }
 
+            if (_configuration.Disabled)
+            {
+                return;
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
 
             var triggerContextDescriptorBatches = triggerContextDiscoveryStrategy.Discover(_configuration, _tracker, _logger);

--- a/src/EntityFrameworkCore.Triggered/TriggeredDbContext.cs
+++ b/src/EntityFrameworkCore.Triggered/TriggeredDbContext.cs
@@ -48,7 +48,7 @@ namespace EntityFrameworkCore.Triggered
 
         public void SetTriggerServiceProvider(IServiceProvider? serviceProvider)
             => _triggerServiceProvider = serviceProvider;
-
+        
         public override int SaveChanges(bool acceptAllChangesOnSuccess)
         {
             bool RaiseAfterSavFailedTriggers(Exception exception)
@@ -62,11 +62,11 @@ namespace EntityFrameworkCore.Triggered
 
             var createdTriggerSession = false;
 
-            if (_triggerSession == null)
+            if (_triggerSession is null)
             {
                 var triggerService = this.GetService<ITriggerService>() ?? throw new InvalidOperationException("Triggers are not configured");
 
-                if (triggerService.Current != null)
+                if (triggerService.Current is not null)
                 {
                     _triggerSession = triggerService.Current;
                 }

--- a/test/EntityFrameworkCore.Triggered.Tests/Internal/CascadingTriggerContextDiscoveryStrategyTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Internal/CascadingTriggerContextDiscoveryStrategyTests.cs
@@ -49,11 +49,11 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
             var subject = new CascadingTriggerContextDiscoveryStrategy("test", false);
             var triggerContextTracker = new TriggerContextTracker(dbContext.ChangeTracker, new EntityAndTypeCascadeStrategy());
             triggerContextTracker.DiscoverChanges().Count();
-            var initialContextDescriptors = subject.Discover(new TriggerOptions { }, triggerContextTracker, new NullLogger<object>()).ToList();
+            var initialContextDescriptors = subject.Discover(new(false, 100), triggerContextTracker, new NullLogger<object>()).ToList();
 
             dbContext.Add(new TestModel { });
 
-            var contextDescriptors = subject.Discover(new TriggerOptions { }, triggerContextTracker, new NullLogger<object>()).ToList();
+            var contextDescriptors = subject.Discover(new(false, 100), triggerContextTracker, new NullLogger<object>()).ToList();
 
             Assert.NotEqual(initialContextDescriptors, contextDescriptors);
         }

--- a/test/EntityFrameworkCore.Triggered.Tests/Internal/NonCascadingTriggerContextDiscoveryStrategyTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Internal/NonCascadingTriggerContextDiscoveryStrategyTests.cs
@@ -44,11 +44,11 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
             var subject = new NonCascadingTriggerContextDiscoveryStrategy("test");
             var triggerContextTracker = new TriggerContextTracker(dbContext.ChangeTracker, new EntityAndTypeCascadeStrategy());
             triggerContextTracker.DiscoverChanges().Count();
-            var initialContextDescriptors = subject.Discover(new TriggerOptions { }, triggerContextTracker, new NullLogger<object>()).ToList();
+            var initialContextDescriptors = subject.Discover(new(false, 0), triggerContextTracker, new NullLogger<object>()).ToList();
 
             dbContext.Add(new TestModel { });
 
-            var contextDescriptors = subject.Discover(new TriggerOptions { }, triggerContextTracker, new NullLogger<object>()).ToList();
+            var contextDescriptors = subject.Discover(new(false, 0), triggerContextTracker, new NullLogger<object>()).ToList();
 
             Assert.Equal(initialContextDescriptors, contextDescriptors);
         }

--- a/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerServiceStub.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/Stubs/TriggerServiceStub.cs
@@ -11,6 +11,8 @@ namespace EntityFrameworkCore.Triggered.Tests.Stubs
 
         public ITriggerSession Current { get; set; }
 
+        public TriggerConfiguration Configuration { get; set; }
+
         public ITriggerSession CreateSession(DbContext context, IServiceProvider serviceProvider)
         {
             CreateSessionCalls += 1;

--- a/test/EntityFrameworkCore.Triggered.Tests/TriggerSessionTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/TriggerSessionTests.cs
@@ -412,5 +412,30 @@ namespace EntityFrameworkCore.Triggered.Tests
             Assert.Equal("test1", _capturedTriggerContext.UnmodifiedEntity.Name);
             Assert.Equal("test2", _capturedTriggerContext.Entity.Name);
         }
+
+        [Fact]
+        public async Task RaiseTriggers_DisabledConfiguration_Noop()
+        {
+            // arrange
+            using var context = new TestDbContext();
+
+            var triggerService = context.GetService<ITriggerService>();
+            triggerService.Configuration = triggerService.Configuration with {
+                Disabled = true
+            };
+
+            var subject = triggerService.CreateSession(context);
+
+            context.TestModels.Add(new TestModel {
+                Id = 1,
+                Name = "test1"
+            });
+
+            // act
+            await subject.RaiseBeforeSaveTriggers();
+
+            // assert
+            Assert.Equal(0, context.TriggerStub.BeforeSaveInvocations.Count);
+        }
     }
 }

--- a/test/EntityFrameworkCore.Triggered.Tests/TriggeredDbContextTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/TriggeredDbContextTests.cs
@@ -539,5 +539,29 @@ namespace EntityFrameworkCore.Triggered.Tests
 
             Assert.Equal(1, triggerServiceStub.LastSession.DisposeCalls);
         }
+
+        [Fact]
+        public async Task SaveChangesAsync_DisabledConfiguration_Noop()
+        {
+            // arrange
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+            var subject = new TestDbContext(serviceProvider, false);
+            var triggerService = subject.GetService<ITriggerService>();
+            triggerService.Configuration = triggerService.Configuration with {
+                Disabled = true
+            };
+
+            subject.TestModels.Add(new TestModel {
+                Id = Guid.NewGuid(),
+                Name = "test1"
+            });
+
+            // act
+            await subject.SaveChangesAsync();
+
+            // assert
+            Assert.Empty(subject.TriggerStub.BeforeSaveInvocations);
+        }
     }
 }


### PR DESCRIPTION
Allow for just-in-time configuration changes to a trigger service including the ability to disable triggers.

Fixes: #114 
