### PR TITLE
Get DbContext/Entry straight from the trigger context

### DIFF
--- a/src/EntityFrameworkCore.Triggered.Extensions/TriggerContextExtensions.cs
+++ b/src/EntityFrameworkCore.Triggered.Extensions/TriggerContextExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace EntityFrameworkCore.Triggered
+{
+    public static class TriggerContextExtensions
+    {
+        /// <summary>
+        /// Get the DbContext EntityEntry for the Entity
+        /// </summary>
+        /// <returns>The EntityEntry associated with the DbContext</returns>
+        /// <exception cref="InvalidOperationException">Throws when the context is not of type <see cref="TriggerContext{TEntity}" /> </exception>
+        public static EntityEntry<TEntity> GetEntry<TEntity>(this ITriggerContext<TEntity> context)
+            where TEntity : class
+        {
+            if (context is not TriggerContext<TEntity> typedContext)
+                throw new InvalidOperationException("GetEntry requires ITriggerContext<T> to be of type TriggerContext<T>");
+
+            return typedContext.Entry;
+        }
+
+        /// <summary>
+        /// Get the DbContext associated with this Entity
+        /// </summary>
+        /// <returns>The DbContext that fired this trigger</returns>
+        /// <exception cref="InvalidOperationException">Throws when the context is not of type <see cref="TriggerContext{TEntity}" /> </exception>
+        public static DbContext GetDbContext<TEntity>(this ITriggerContext<TEntity> context)
+            where TEntity : class
+        {
+            if (context is not TriggerContext<TEntity> typedContext)
+                throw new InvalidOperationException("GetDbContext requires ITriggerContext<T> to be of type TriggerContext<T>");
+
+            return typedContext.Entry.Context;
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Triggered/Internal/TriggerContextDescriptor.cs
+++ b/src/EntityFrameworkCore.Triggered/Internal/TriggerContextDescriptor.cs
@@ -6,7 +6,7 @@ namespace EntityFrameworkCore.Triggered.Internal
 {
     public readonly struct TriggerContextDescriptor
     {
-        static readonly ConcurrentDictionary<Type, Func<object, PropertyValues?, ChangeType, EntityBagStateManager, object>> _cachedTriggerContextFactories = new();
+        static readonly ConcurrentDictionary<Type, Func<EntityEntry, PropertyValues?, ChangeType, EntityBagStateManager, object>> _cachedTriggerContextFactories = new();
 
         readonly EntityEntry _entityEntry;
         readonly ChangeType _changeType;
@@ -37,11 +37,11 @@ namespace EntityFrameworkCore.Triggered.Internal
             var entityType = entityEntry.Entity.GetType();
 
             var triggerContextFactory = _cachedTriggerContextFactories.GetOrAdd(entityType, entityType =>
-                (Func<object, PropertyValues?, ChangeType, EntityBagStateManager, object >)typeof(TriggerContextFactory<>).MakeGenericType(entityType)
+                (Func<EntityEntry, PropertyValues?, ChangeType, EntityBagStateManager, object >)typeof(TriggerContextFactory<>).MakeGenericType(entityType)
                     !.GetMethod(nameof(TriggerContextFactory<object>.Activate))
-                    !.CreateDelegate(typeof(Func<object, PropertyValues?, ChangeType, EntityBagStateManager, object>)));
+                    !.CreateDelegate(typeof(Func<EntityEntry, PropertyValues?, ChangeType, EntityBagStateManager, object>)));
 
-            return triggerContextFactory(entityEntry.Entity, originalValues, changeType, entityBagStateManager);
+            return triggerContextFactory(entityEntry, originalValues, changeType, entityBagStateManager);
         }
     }
 }

--- a/src/EntityFrameworkCore.Triggered/Internal/TriggerContextFactory.cs
+++ b/src/EntityFrameworkCore.Triggered/Internal/TriggerContextFactory.cs
@@ -1,30 +1,31 @@
 ﻿using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EntityFrameworkCore.Triggered.Internal
 {
     public static class TriggerContextFactory<TEntityType>
         where TEntityType : class
     {
-        readonly static Func<object, PropertyValues?, ChangeType, EntityBagStateManager, TriggerContext<TEntityType>> _factoryMethod = CreateFactoryMethod();
+        readonly static Func<EntityEntry, PropertyValues?, ChangeType, EntityBagStateManager, TriggerContext<TEntityType>> _factoryMethod = CreateFactoryMethod();
 
-        static Func<object, PropertyValues?, ChangeType, EntityBagStateManager, TriggerContext<TEntityType>> CreateFactoryMethod()
+        static Func<EntityEntry, PropertyValues?, ChangeType, EntityBagStateManager, TriggerContext<TEntityType>> CreateFactoryMethod()
         {
-            var entityParamExpression = Expression.Parameter(typeof(object), "object");
+            var entityEntryParamExpression = Expression.Parameter(typeof(EntityEntry), "entityEntry");
             var originalValuesParamExpression = Expression.Parameter(typeof(PropertyValues), "originalValues");
             var changeTypeParamExpression = Expression.Parameter(typeof(ChangeType), "changeType");
             var entityBagStateManagerExpression = Expression.Parameter(typeof(EntityBagStateManager), "entityBagStateManager");
 
-            return Expression.Lambda<Func<object, PropertyValues?, ChangeType, EntityBagStateManager, TriggerContext<TEntityType>>>(
+            return Expression.Lambda<Func<EntityEntry, PropertyValues?, ChangeType, EntityBagStateManager, TriggerContext<TEntityType>>>(
                 Expression.New(
-                    typeof(TriggerContext<>).MakeGenericType(typeof(TEntityType)).GetConstructor(new[] { typeof(object), typeof(PropertyValues), typeof(ChangeType), typeof(EntityBagStateManager) })!,
-                    entityParamExpression,
+                    typeof(TriggerContext<>).MakeGenericType(typeof(TEntityType)).GetConstructor(new[] { typeof(EntityEntry), typeof(PropertyValues), typeof(ChangeType), typeof(EntityBagStateManager) })!,
+                    entityEntryParamExpression,
                     originalValuesParamExpression,
                     changeTypeParamExpression,
                     entityBagStateManagerExpression
                 ),
-                entityParamExpression,
+                entityEntryParamExpression,
                 originalValuesParamExpression,
                 changeTypeParamExpression,
                 entityBagStateManagerExpression
@@ -32,7 +33,7 @@ namespace EntityFrameworkCore.Triggered.Internal
             .Compile();
         }
 
-        public static object Activate(object entity, PropertyValues? originalValues, ChangeType changeType, EntityBagStateManager entityBagStateManager)
-            => _factoryMethod(entity, originalValues, changeType, entityBagStateManager);
+        public static object Activate(EntityEntry entityEntry, PropertyValues? originalValues, ChangeType changeType, EntityBagStateManager entityBagStateManager)
+            => _factoryMethod(entityEntry, originalValues, changeType, entityBagStateManager);
     }
 }

--- a/src/EntityFrameworkCore.Triggered/TriggerContext.cs
+++ b/src/EntityFrameworkCore.Triggered/TriggerContext.cs
@@ -7,23 +7,23 @@ namespace EntityFrameworkCore.Triggered
     public class TriggerContext<TEntity> : ITriggerContext<TEntity>
         where TEntity : class
     {
-        readonly TEntity _entity;
+        readonly EntityEntry _entityEntry;
         readonly ChangeType _type;
         readonly PropertyValues? _originalValues;
         readonly EntityBagStateManager _entityBagStateManager;
 
         TEntity? _unmodifiedEntity;
 
-        public TriggerContext(object entity, PropertyValues? originalValues, ChangeType changeType, EntityBagStateManager entityBagStateManager)
+        public TriggerContext(EntityEntry entityEntry, PropertyValues? originalValues, ChangeType changeType, EntityBagStateManager entityBagStateManager)
         {
-            _entity = (TEntity)entity;
+            _entityEntry = entityEntry;
             _originalValues = originalValues;
             _type = changeType;
             _entityBagStateManager = entityBagStateManager;
         }
 
         public ChangeType ChangeType => _type;
-        public TEntity Entity => _entity;
+        public TEntity Entity => (TEntity)_entityEntry.Entity;
         public TEntity? UnmodifiedEntity
         {
             get
@@ -44,6 +44,8 @@ namespace EntityFrameworkCore.Triggered
             }
         }
 
-        public IDictionary<object, object> Items => _entityBagStateManager.GetForEntity(_entity);
+        public IDictionary<object, object> Items => _entityBagStateManager.GetForEntity(_entityEntry.Entity);
+
+        public EntityEntry<TEntity> Entry => (EntityEntry<TEntity>)_entityEntry;
     }
 }

--- a/test/EntityFrameworkCore.Triggered.Extensions.Tests/GlobalSuppressions.cs
+++ b/test/EntityFrameworkCore.Triggered.Extensions.Tests/GlobalSuppressions.cs
@@ -5,4 +5,4 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "<Pending>", Scope = "member", Target = "~M:EntityFrameworkCore.Triggered.Extensions.Tests.TriggerContextOptionsBuilderExtensionsTests.AddAssemblyTriggers_AbstractTrigger_GetsIgnored")]
+[assembly: SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "False warning", Scope = "namespaceanddescendants", Target = "~N:EntityFrameworkCore.Triggered.Extensions.Tests")]

--- a/test/EntityFrameworkCore.Triggered.Extensions.Tests/TriggerContextExtensionsTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Extensions.Tests/TriggerContextExtensionsTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit;
+
+namespace EntityFrameworkCore.Triggered.Extensions.Tests
+{
+    public class TriggerContextExtensionsTests
+    {
+        record TestEntity(int Id);
+
+        class SampleDbContext : DbContext
+        {
+            public DbSet<TestEntity> Entities { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                optionsBuilder.UseInMemoryDatabase(nameof(TriggerContextExtensionsTests));
+                optionsBuilder.ConfigureWarnings(warningOptions => {
+                    warningOptions.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning);
+                });
+
+            }
+        }
+
+        [Fact]
+        public void GetDbContext()
+        {
+            using var expected = new SampleDbContext();
+            var entity = new TestEntity(1);
+            var triggerContext = new TriggerContext<TestEntity>(expected.Add(entity), null, ChangeType.Added, new Internal.EntityBagStateManager());
+
+            var actual = triggerContext.GetDbContext();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetEntry()
+        {
+            using var dbContext = new SampleDbContext();
+            var entity = new TestEntity(1);
+            var expected = dbContext.Add(entity);
+            var triggerContext = new TriggerContext<TestEntity>(expected, null, ChangeType.Added, new Internal.EntityBagStateManager());
+
+            var actual = triggerContext.GetEntry();
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/EntityFrameworkCore.Triggered.Tests/TriggerContextTests.cs
+++ b/test/EntityFrameworkCore.Triggered.Tests/TriggerContextTests.cs
@@ -27,7 +27,7 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
         {
             using var dbContext = new TestDbContext();
             var sample1 = new TestModel() { Id = 1 };
-            var subject = new TriggerContext<object>(dbContext.Entry(sample1).Entity, dbContext.Entry(sample1).OriginalValues, ChangeType.Added, new());
+            var subject = new TriggerContext<object>(dbContext.Entry(sample1), dbContext.Entry(sample1).OriginalValues, ChangeType.Added, new());
 
             Assert.Null(subject.UnmodifiedEntity);
         }
@@ -37,7 +37,7 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
         {
             using var dbContext = new TestDbContext();
             var sample1 = new TestModel();
-            var subject = new TriggerContext<object>(dbContext.Entry(sample1).Entity, dbContext.Entry(sample1).OriginalValues, ChangeType.Deleted, new());
+            var subject = new TriggerContext<object>(dbContext.Entry(sample1), dbContext.Entry(sample1).OriginalValues, ChangeType.Deleted, new());
 
             Assert.NotNull(subject.UnmodifiedEntity);
         }
@@ -47,7 +47,7 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
         {
             using var dbContext = new TestDbContext();
             var sample1 = new TestModel();
-            var subject = new TriggerContext<object>(dbContext.Entry(sample1).Entity, dbContext.Entry(sample1).OriginalValues, ChangeType.Modified, new());
+            var subject = new TriggerContext<object>(dbContext.Entry(sample1), dbContext.Entry(sample1).OriginalValues, ChangeType.Modified, new());
 
             Assert.NotNull(subject.UnmodifiedEntity);
         }
@@ -60,7 +60,7 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
             dbContext.Add(sample1);
             dbContext.SaveChanges();
 
-            var subject = new TriggerContext<TestModel>(dbContext.Entry(sample1).Entity, dbContext.Entry(sample1).OriginalValues, ChangeType.Modified, new());
+            var subject = new TriggerContext<TestModel>(dbContext.Entry(sample1), dbContext.Entry(sample1).OriginalValues, ChangeType.Modified, new());
             sample1.Name = "test2";
 
             Assert.NotNull(subject.UnmodifiedEntity);
@@ -77,7 +77,7 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
             dbContext.Add(sample1);
             dbContext.SaveChanges();
 
-            var subject = new TriggerContext<TestModel>(dbContext.Entry(sample1).Entity, dbContext.Entry(sample1).OriginalValues.Clone(), ChangeType.Modified, new());
+            var subject = new TriggerContext<TestModel>(dbContext.Entry(sample1), dbContext.Entry(sample1).OriginalValues.Clone(), ChangeType.Modified, new());
             sample1.Name = "test2";
 
             dbContext.SaveChanges();
@@ -91,7 +91,7 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
         {
             using var dbContext = new TestDbContext();
             var sample1 = new TestModel();
-            var subject = new TriggerContext<object>(dbContext.Entry(sample1).Entity, dbContext.Entry(sample1).OriginalValues, default, new());
+            var subject = new TriggerContext<object>(dbContext.Entry(sample1), dbContext.Entry(sample1).OriginalValues, default, new());
 
             Assert.NotNull(subject.Entity);
         }
@@ -101,7 +101,7 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
         {
             using var dbContext = new TestDbContext();
             var sample1 = new TestModel();
-            var subject = new TriggerContext<object>(dbContext.Entry(sample1).Entity, dbContext.Entry(sample1).OriginalValues, ChangeType.Modified, new());
+            var subject = new TriggerContext<object>(dbContext.Entry(sample1), dbContext.Entry(sample1).OriginalValues, ChangeType.Modified, new());
 
             Assert.Equal(ChangeType.Modified, subject.ChangeType);
         }
@@ -111,7 +111,7 @@ namespace EntityFrameworkCore.Triggered.Tests.Internal
         {
             using var dbContext = new TestDbContext();
             var sample1 = new TestModel();
-            var subject = new TriggerContext<object>(dbContext.Entry(sample1).Entity, dbContext.Entry(sample1).OriginalValues, ChangeType.Modified, new());
+            var subject = new TriggerContext<object>(dbContext.Entry(sample1), dbContext.Entry(sample1).OriginalValues, ChangeType.Modified, new());
 
             var expectedInstance = subject.Items;
             Assert.Equal(expectedInstance, subject.Items);


### PR DESCRIPTION
New extensions are now exposed to get the DbContext/Entry straight from the ITriggerContext. This will only work if the concrete type of ITriggerContext is of type TriggerContext. 