### PR TITLE
Allow AddTriggeredDbContextFactory to use to the service provider

### DIFF
--- a/src/EntityFrameworkCore.Triggered/Extensions/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Triggered/Extensions/ServiceCollectionExtensions.cs
@@ -76,11 +76,11 @@ namespace Microsoft.Extensions.DependencyInjection
             return serviceCollection;
         }
 
-        public static IServiceCollection AddTriggeredDbContextFactory<TContext>(this IServiceCollection serviceCollection, Action<DbContextOptionsBuilder>? optionsAction = null, ServiceLifetime lifetime = ServiceLifetime.Singleton)
+        public static IServiceCollection AddTriggeredDbContextFactory<TContext>(this IServiceCollection serviceCollection, Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction = null, ServiceLifetime lifetime = ServiceLifetime.Singleton)
             where TContext : DbContext
         {
-            serviceCollection.AddDbContextFactory<TContext>(options => {
-                optionsAction?.Invoke(options);
+            serviceCollection.AddDbContextFactory<TContext>((serviceProvider, options) => {
+                optionsAction?.Invoke(serviceProvider, options);
                 options.UseTriggers();
             }, lifetime);
 


### PR DESCRIPTION
AddDbContextFactory has an overload that passes the serviceProvider to the callback, update this library so it does the same